### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/services/gateway/nodejs/src/lib/authentication.js
+++ b/services/gateway/nodejs/src/lib/authentication.js
@@ -105,7 +105,7 @@ module.exports = opts => {
       // return token and user information to user
       res.status(200).send({ token, user: userData });
     } catch (err) {
-      console.error(`Error logging in for ${username}: `, err);
+      console.error('Error logging in for %s:', username, err);
       return sendLoginError();
     }
   };


### PR DESCRIPTION
Potential fix for [https://github.com/Coveros/codeveros/security/code-scanning/1](https://github.com/Coveros/codeveros/security/code-scanning/1)

To fix the problem, we should avoid including user-controlled data directly in the format string passed as the first argument to `console.error`. Instead, we should use a static format string with a `%s` placeholder and pass the user input as a separate argument. This ensures that any special characters in the user input are treated as data, not as format specifiers. Specifically, in `services/gateway/nodejs/src/lib/authentication.js`, line 108 should be changed from:
```js
console.error(`Error logging in for ${username}: `, err);
```
to:
```js
console.error('Error logging in for %s:', username, err);
```
No new imports or methods are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
