### PR TITLE
Change default code owner to jwhollingsworth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner of everything
-* @justin-coveros
+* @jwhollingsworth


### PR DESCRIPTION
This pull request updates the code ownership assignment in the `.github/CODEOWNERS` file.

- Changed the default owner for all files from `@justin-coveros` to `@jwhollingsworth`.